### PR TITLE
Makes tkinter dependency optional

### DIFF
--- a/ColorKit/colorkit.py
+++ b/ColorKit/colorkit.py
@@ -1,7 +1,9 @@
 # Author: Benjamin M.
-from tkinter import colorchooser
+try:
+    import tkinter as tk
+except ImportError as exh:
+    tk = exh
 import colorsys
-import tkinter as tk
 from random import randint
 import colorsys
 import math
@@ -10,32 +12,36 @@ import math
 class ColorPicker:
     def __init__(self):
         self.color = None
+        if isinstance(tk, Exception):
+            raise tk
 
     def rgb(self):
-        self.color = colorchooser.askcolor()
+        self.color = tk.colorchooser.askcolor()
         rgb = self.color[0]
         return rgb
     
     def hex(self):
-        self.color = colorchooser.askcolor()
+        self.color = tk.colorchooser.askcolor()
         rgb = self.color[0]
         hex = rgb_to_hex(rgb)
         return hex
     
     def hsl(self):
-        self.color = colorchooser.askcolor()
+        self.color = tk.colorchooser.askcolor()
         rgb = self.color[0]
         hsl = rgb_to_hsl(rgb)
         return hsl
     
     def cmyk(self):
-        self.color = colorchooser.askcolor()
+        self.color = tk.colorchooser.askcolor()
         rgb = self.color[0]
         cmyk = rgb_to_cmyk(rgb)
         return cmyk
     
 # Color viewer
 def ViewColor(color):
+    if isinstance(tk, Exception):
+        raise tk
     hex = color
     if "#" not in color:
         try:


### PR DESCRIPTION
## Description

This is a useful library, but there are use cases where tkinter (or any other GUI) wouldn't be available.

## Changes

1. Wraps the `tkinter` import in a `try`/`except` block.
2. Retains the import exception, if any.
3. Checks if `tk` is an exception in `ColorPicker.__init__` and `ViewColor`, and raises it.
4. Removes a redundant `tkinter` import.

This effectively prevents the exception from being raised when no Tkinter-dependent code is run.